### PR TITLE
Update to node24 and prepare for 1.2.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,19 +7,19 @@ jobs:
   test-action:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: create-json
         id: create-json
-        uses: jsdaniell/create-json@v1.2.3
+        uses: jsdaniell/create-json@v1.2.4
         with:
           name: "test.json"
-          json: '{"name":"json sucessfully created!"}'
+          json: '{"name":"json successfully created!"}'
       - run: sh ./test-json.sh
   publish:
     needs: [test-action]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - uses: TG908/publish-github-action@v1
         with:
           github_token: ${{ secrets.TOKEN }}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and use in this way:
 ```yaml
     - name: create-json
       id: create-json
-      uses: jsdaniell/create-json@v1.2.3
+      uses: jsdaniell/create-json@v1.2.4
       with:
         name: "credentials.json"
         json: ${{ secrets.MY_JSON }}
@@ -43,7 +43,7 @@ Or just declare a string of a json on the property `json` like:
 ```yaml
     - name: create-json
       id: create-json
-      uses: jsdaniell/create-json@v1.2.3
+      uses: jsdaniell/create-json@v1.2.4
       with:
         name: "new-json-file.json"
         json: '{"name":"jsdaniell", "password":"mypass"}'
@@ -55,7 +55,7 @@ You also can save the json on a subdirectory using the property `dir`:
 ```yaml
     - name: create-json
       id: create-json
-      uses: jsdaniell/create-json@v1.2.3
+      uses: jsdaniell/create-json@v1.2.4
       with:
         name: "credentials.json"
         json: ${{ secrets.CREDENTIALS_JSON }}
@@ -69,14 +69,14 @@ If you want to create more than one json files, you have to specify different ID
 ```yaml
     - name: create-json
       id: create-json-1 # First ID
-      uses: jsdaniell/create-json@v1.2.3
+      uses: jsdaniell/create-json@v1.2.4
       with:
         name: "credentials.json"
         json: ${{ secrets.CREDENTIALS_JSON }}
         dir: 'src/'
     - name: create-json
       id: create-json-2  # Second ID
-      uses: jsdaniell/create-json@v1.2.3
+      uses: jsdaniell/create-json@v1.2.4
       with:
         name: "other.json"
         json: '{"name":"jsdaniell", "password":"mypass"}'
@@ -103,7 +103,7 @@ jobs:
       - run: cd src && go mod vendor
       - name: create-json
         id: create-json
-        uses: jsdaniell/create-json@v1.2.3
+        uses: jsdaniell/create-json@v1.2.4
         with:
           name: "devdatatools-firebase-adminsdk.json"
           json: ${{ secrets.CREDENTIALS_JSON }}
@@ -123,4 +123,4 @@ After commit and use with Heroku the file is deleted after the workflow and the 
 
 You can submit an issue or PR anytime for the improvement this action!
 
-Version v1.2.3 (Node 20)
+Version v1.2.4 (Node 24)

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ outputs:
   successfully:
     description: 'Feedback message of success '
 runs:
-  using: "node20"
+  using: "node24"
   main: "./dist/index.js"
 branding:
   icon: 'file-text'


### PR DESCRIPTION
- Update node version to 24 due to [deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
   - Issue raised: https://github.com/jsdaniell/create-json/issues/10#issue-4072769004
- Prepared for the next version - 1.2.4
- Updated actions/checkout to the latest version